### PR TITLE
Only show a locker to its building's admin

### DIFF
--- a/app/controllers/lockers_controller.rb
+++ b/app/controllers/lockers_controller.rb
@@ -22,7 +22,7 @@ class LockersController < ApplicationController
 
   # POST /lockers or /lockers.json
   def create
-    @locker = Locker.new(locker_params)
+    @locker = Locker.new(locker_params.with_defaults(building: current_user&.building))
 
     respond_to do |format|
       if @locker.save

--- a/app/controllers/lockers_controller.rb
+++ b/app/controllers/lockers_controller.rb
@@ -6,7 +6,7 @@ class LockersController < ApplicationController
 
   # GET /lockers or /lockers.json
   def index
-    @pagy, @lockers = pagy(Locker.search(field: :location, term: params[:search]).order(:location))
+    @pagy, @lockers = pagy(Locker.search(field: :location, term: params[:search]).where(building: current_user.building).order(:location))
   end
 
   # GET /lockers/1 or /lockers/1.json

--- a/app/models/locker.rb
+++ b/app/models/locker.rb
@@ -7,9 +7,10 @@ class Locker < ApplicationRecord
 
   belongs_to :building, optional: true
 
-  def self.available_lockers
+  def self.available_lockers(building:)
     where.not(id: LockerAssignment.where(released_date: nil).pluck(:locker_id))
          .where(disabled: [false, nil])
+         .where(building: building)
   end
 
   def size_choices

--- a/app/models/locker_application.rb
+++ b/app/models/locker_application.rb
@@ -46,8 +46,8 @@ class LockerApplication < ApplicationRecord
     prepare_choices_for_lux(department_list)
   end
 
-  def available_lockers_in_area_and_size
-    context = Locker.available_lockers
+  def available_lockers_in_area_and_size(building:)
+    context = Locker.available_lockers(building: building)
     context = context.where(floor: preferred_general_area) if preferred_general_area.present? && preferred_general_area != 'No preference'
     context = context.where(size: preferred_size) if preferred_size.present?
     context.order(:location)

--- a/app/models/locker_assignment.rb
+++ b/app/models/locker_assignment.rb
@@ -51,16 +51,17 @@ class LockerAssignment < ApplicationRecord
     end
   end
 
-  def locker_choices
-    available = Locker.available_lockers.pluck(:id, :location, :size)
+  def locker_choices(building:)
+    available = Locker.available_lockers(building: building).pluck(:id, :location, :size)
     prepare_locker_choices_for_lux(available)
   end
 
-  def preferred_locker_choices
+  def preferred_locker_choices(building:)
     available = if locker_application.blank?
                   []
                 else
-                  locker_application.available_lockers_in_area_and_size.pluck(:id, :location, :size)
+                  locker_application.available_lockers_in_area_and_size(building: building)
+                                    .pluck(:id, :location, :size)
                 end
     prepare_locker_choices_for_lux(available)
   end

--- a/app/views/locker_assignments/_form.html.erb
+++ b/app/views/locker_assignments/_form.html.erb
@@ -40,7 +40,7 @@
                       id="locker_assignment_locker_id"
                       width="expand"
                       value="<%= locker_assignment.locker %>"
-                      :options="<%= locker_assignment.preferred_locker_choices.to_json %>"
+                      :options="<%= locker_assignment.preferred_locker_choices(building: current_user&.building).to_json %>"
         ></input-select>
    </grid-item>
 
@@ -48,7 +48,7 @@
      <input-select label="Lockers Available in Any Area" name="locker_assignment[any_locker_id]"
                       id="any_locker_assignment_locker_id"
                       width="expand"
-                      :options="<%= locker_assignment.locker_choices.to_json %>"
+                      :options="<%= locker_assignment.locker_choices(building: current_user&.building).to_json %>"
         ></input-select>
    </grid-item>
 

--- a/app/views/lockers/index.html.erb
+++ b/app/views/lockers/index.html.erb
@@ -2,7 +2,7 @@
 <card id="locker-form-header" size="full-width">
   <card-header>
     <!-- Hyperlink is the text screen readers would read, we don't want to wrap the entire card -->
-    <heading level="h1" size="h3">Lockers</heading>
+    <heading level="h1" size="h3"><%= current_user&.building&.name %> Lockers</heading>
   </card-header>
   <card-content>
   <%= form_tag(lockers_path, method: :get) do %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,6 +23,7 @@ def locker_attributes(row)
   attributes[:floor] = row['floor_str']
   attributes['size'] = locker_size(row['type'])
   attributes[:disabled] = row['maxOccupancy'] == '0'
+  attributes[:building] = default_building
   attributes
 end
 
@@ -100,6 +101,10 @@ def setup_locker(row, user)
   else
     setup_study_room(row, user)
   end
+end
+
+def default_building
+  Building.find_by_name('Firestone Library')
 end
 
 # file was generate using `SELECT TOP * FROM [Admins]` query

--- a/docs/buildings.md
+++ b/docs/buildings.md
@@ -1,0 +1,9 @@
+As an admin in the system, you can only see lockers that are associated with your
+building.  If you need to use the UI as the admin for a different building, you
+can do so with the rails console:
+
+```
+me = User.find_by_uid 'net_id'
+me.building = Building.find_by_name 'Firestone Library' # or 'Lewis Library'
+me.save
+```

--- a/spec/controllers/lockers_controller_spec.rb
+++ b/spec/controllers/lockers_controller_spec.rb
@@ -4,11 +4,27 @@ require 'rails_helper'
 
 RSpec.describe LockersController do
   render_views
-  let(:building) { FactoryBot.create :building, name: 'Lewis Library' }
-  let(:user) { FactoryBot.create :user, :admin, building: building }
+  let(:firestone) { FactoryBot.create :building, name: 'Firestone Library' }
+  let(:lewis) { FactoryBot.create :building, name: 'Lewis Library' }
+  let(:user) { FactoryBot.create :user, :admin, building: lewis }
+  let(:firestone_locker) { FactoryBot.create :locker, building: firestone }
+  let(:lewis_locker) { FactoryBot.create :locker, building: lewis }
 
   before do
     sign_in user
+  end
+
+  describe '#index' do
+    before do
+      firestone_locker
+      lewis_locker
+    end
+
+    it "only includes lockers for the admin's building" do
+      controller.index
+      expect(controller.instance_variable_get('@lockers')).to include(lewis_locker)
+      expect(controller.instance_variable_get('@lockers')).not_to include(firestone_locker)
+    end
   end
 
   context 'when Lewis staff features are turned on' do

--- a/spec/features/locker_create_spec.rb
+++ b/spec/features/locker_create_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'securerandom'
+
+RSpec.describe 'Locker Create', type: :feature, js: true do
+  let(:building) { FactoryBot.create(:building, name: 'Firestone Library') }
+  let(:user) { FactoryBot.create(:user, :admin, building: building) }
+
+  before do
+    sign_in user
+    building
+  end
+
+  it 'enables me to create a locker at my building' do
+    visit '/lockers/new'
+    fill_in 'Location', with: SecureRandom.hex
+    select 4, from: 'Size'
+    fill_in 'Combination', with: SecureRandom.hex
+    fill_in 'General Area', with: SecureRandom.hex
+
+    expect do
+      click_button 'Submit Locker'
+    end.to change(Locker, :count).by(1)
+
+    expect(Locker.order('created_at').last.building).to eq(building)
+  end
+end

--- a/spec/models/locker_application_spec.rb
+++ b/spec/models/locker_application_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe LockerApplication, type: :model do
   subject(:locker_application) { described_class.new(user: user) }
 
   let(:user) { nil }
+  let(:building) { FactoryBot.create(:building) }
 
   it 'responds to the attributes' do
     expect(locker_application.user).to be_nil
@@ -26,14 +27,14 @@ RSpec.describe LockerApplication, type: :model do
     let!(:locker4) {  FactoryBot.create :locker, floor: locker_application.preferred_general_area, size: 4 }
 
     it 'to only returns unassigned lockers in area of the right size' do
-      expect(locker_application.available_lockers_in_area_and_size).to contain_exactly(locker4)
+      expect(locker_application.available_lockers_in_area_and_size(building: building)).to contain_exactly(locker4)
     end
 
     context 'no size preference shows any' do
       let(:locker_application) { FactoryBot.create :locker_application, preferred_size: nil }
 
       it 'to only returns unassigned lockers in area' do
-        expect(locker_application.available_lockers_in_area_and_size).to contain_exactly(locker3, locker4)
+        expect(locker_application.available_lockers_in_area_and_size(building: building)).to contain_exactly(locker3, locker4)
       end
     end
 
@@ -41,7 +42,7 @@ RSpec.describe LockerApplication, type: :model do
       let(:locker_application) { FactoryBot.create :locker_application, preferred_size: 4, preferred_general_area: 'No preference' }
 
       it 'to only returns unassigned lockers in area' do
-        expect(locker_application.available_lockers_in_area_and_size).to contain_exactly(locker4)
+        expect(locker_application.available_lockers_in_area_and_size(building: building)).to contain_exactly(locker4)
       end
     end
 
@@ -49,7 +50,7 @@ RSpec.describe LockerApplication, type: :model do
       let(:locker3) { FactoryBot.create :locker, floor: locker_application.preferred_general_area, size: 4, disabled: true }
 
       it 'does not return a disabled locker, even if it otherwise meets the criteria' do
-        expect(locker_application.available_lockers_in_area_and_size).not_to include(locker3)
+        expect(locker_application.available_lockers_in_area_and_size(building: building)).not_to include(locker3)
       end
     end
   end

--- a/spec/models/locker_spec.rb
+++ b/spec/models/locker_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Locker, type: :model do
     let(:locker2) {  FactoryBot.create :locker }
     let(:locker3) {  FactoryBot.create :locker }
     let(:locker4) {  FactoryBot.create :locker }
+    let(:our_building) { FactoryBot.create :building }
+    let(:other_building) { FactoryBot.create :building, name: 'Other library' }
 
     before do
       locker_assignment
@@ -19,7 +21,7 @@ RSpec.describe Locker, type: :model do
     end
 
     it 'to only returns unassigned lockers in area' do
-      expect(described_class.available_lockers).to contain_exactly(locker2, locker3, locker4)
+      expect(described_class.available_lockers(building: our_building)).to contain_exactly(locker2, locker3, locker4)
     end
 
     context 'disabled lockers' do
@@ -28,7 +30,15 @@ RSpec.describe Locker, type: :model do
       let(:locker4) { FactoryBot.create :locker, disabled: nil }
 
       it 'does not include lockers that have been disabled' do
-        expect(described_class.available_lockers).to contain_exactly(locker3, locker4)
+        expect(described_class.available_lockers(building: our_building)).to contain_exactly(locker3, locker4)
+      end
+    end
+
+    context 'when lockers are at another building' do
+      let(:locker2) { FactoryBot.create :locker, building: other_building }
+
+      it "does not include the other building's lockers" do
+        expect(described_class.available_lockers(building: our_building)).to contain_exactly(locker3, locker4)
       end
     end
   end

--- a/spec/views/lockers/index.html.erb_spec.rb
+++ b/spec/views/lockers/index.html.erb_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'lockers/index', type: :view do
+  let(:building) { FactoryBot.create :building, name: 'My Excellent Library' }
+  let(:user) { FactoryBot.create :user, building: building }
+
   before do
     @lockers = assign(:lockers, [
                         Locker.create!(
@@ -37,6 +40,7 @@ RSpec.describe 'lockers/index', type: :view do
                         )
                       ])
     assign(:pagy, instance_double(Pagy, prev: nil, next: nil, series: [], vars: { page: 1, items: 2, params: {} }))
+    allow(view).to receive(:current_user).and_return(user)
   end
 
   it 'renders a list of lockers' do
@@ -53,5 +57,10 @@ RSpec.describe 'lockers/index', type: :view do
     expect(rendered).to match(/#{edit_locker_path(@lockers[0])}/)
     expect(rendered).to match(/#{locker_path(@lockers[1])}/)
     expect(rendered).to match(/#{edit_locker_path(@lockers[1])}/)
+  end
+
+  it "has a header containing the name of the admin user's library" do
+    render
+    assert_select 'heading', text: 'My Excellent Library Lockers'
   end
 end


### PR DESCRIPTION
closes #111 

Some suggested steps to test in the browser:

1. Deploy this branch to staging
1. At https://lockers-and-study-spaces-staging.princeton.edu/flipflop, turn on "Lewis library Staff features"
1. SSH into staging
1. In the rails console:
```
me = User.find_by_uid 'net_id'
me.admin = true
me.building = Building.find_by_name 'Lewis Library'
me.save
```
1. At https://lockers-and-study-spaces-staging.princeton.edu/lockers, notice that no Lewis lockers show up
1. Locker Management > New Locker.
1. Confirm that your new locker shows up under Locker Management > Lockers.
1. Confirm that your new locker shows up as an option in the dropdowns under Locker Management > Assign Lockers > Assign Locker.
1. Use the rails console to switch your building back to Firestone.
1. Confirm that your new locker (created as a Lewis admin) does not display in Locker Management > Lockers.  But all your new ones do!