### PR TITLE
i86: add lang attribute to <html> tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ group :development do
 end
 
 group :test do
+  gem 'axe-core-rspec'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,17 @@ GEM
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
+    axe-core-api (4.4.2)
+      dumb_delegator
+      virtus
+    axe-core-rspec (4.4.2)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.11.1)
@@ -94,6 +105,8 @@ GEM
       xpath (~> 3.2)
     childprocess (4.1.0)
     chronic (0.10.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -103,6 +116,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -111,6 +126,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    dumb_delegator (1.0.0)
     erubi (1.10.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
@@ -126,6 +142,7 @@ GEM
     honeybadger (4.12.1)
     i18n (1.11.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -295,12 +312,17 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
+    thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.1.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -335,6 +357,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  axe-core-rspec
   bootsnap (>= 1.1.0)
   byebug
   capistrano (~> 3.10)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <title>LockerAndStudySpaces</title>
     <%= csrf_meta_tags %>

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'axe-rspec'
+
+describe 'accessibility', type: :feature, js: true do
+  context 'when visiting the home page' do
+    before do
+      visit '/'
+    end
+
+    it 'complies with wcag' do
+      expect(page).to be_axe_clean
+        .according_to(:wcag2a, :wcag2aa)
+        .skipping(:'duplicate-id-aria', :list)
+    end
+  end
+end


### PR DESCRIPTION
closes #86 

I was inspired by orangelight's axe-core spec, so rather than write my own test for the lang attribute, I brought in the axe-core-rspec gem.