### PR TITLE
i100: Improve landing page design

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,4 +14,5 @@
  */
 
 @import "card";
+@import "home_page";
 @import "locker_applications";

--- a/app/assets/stylesheets/home_page.scss
+++ b/app/assets/stylesheets/home_page.scss
@@ -1,0 +1,17 @@
+// Makes home page vertically centered
+.stretch-height {
+    height: calc(100vh - 88px);
+    text-align: center;
+}
+
+.stretch-height p.lux-text-style {
+    border: solid 2px #41464e;
+    padding: 20% 20px 20% 20px;
+    line-height: 250%;
+}
+
+.lux-link.button {
+    white-space: nowrap;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,1 +1,13 @@
-You must <%= button_to "Login", user_cas_omniauth_authorize_path %> to view the requested resource.
+<wrapper>
+  <grid-container class="stretch-height">
+    <grid-item columns="sm-2 lg-2"></grid-item>
+    <grid-item vertical="center" columns="sm-8 lg-8">
+      <text-style variation="default">
+        You must
+        <hyperlink href="<%= user_cas_omniauth_authorize_path %>" variation="button solid" data-method="post" size="large">Login with NetID</hyperlink>
+        to view the requested resource.
+      </text-style>
+    </grid-item>
+    <grid-item columns="sm-2 lg-2"></grid-item>
+  </grid-container>
+</wrapper>


### PR DESCRIPTION
closes #100 

Based on [the first screen of this prototype](https://xd.adobe.com/view/4a29213b-99bf-4c8c-9a89-9e165a746bb7-1f7a/) and the approvals home page.

Screenshot for a wide screen:
<img width="1723" alt="content is centered, with a lot of whitespace and a prominent login button in the middle of some explanatory text" src="https://user-images.githubusercontent.com/7086943/198366698-6b2e4e63-e924-433b-a4f4-26caf7b789d8.png">


Screenshot for a mobile screen:
<img width="415" alt="content is centered, with a large Login button in the middle" src="https://user-images.githubusercontent.com/7086943/198366707-4a754d30-47bf-47f1-8ee4-25e7ebe1d09d.png">

