### PR TITLE
Return to status quo for admins creating user apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
   gem 'capistrano-passenger'
   gem 'capistrano-rails', '~> 1.6', require: false
   gem 'factory_bot'
+  gem 'rails-controller-testing'
   gem 'rubocop'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,10 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.6.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -379,6 +383,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 4.3)
   rails (~> 6.0)
+  rails-controller-testing
   rspec-rails
   rspec_junit_formatter
   rubocop

--- a/app/controllers/locker_applications_controller.rb
+++ b/app/controllers/locker_applications_controller.rb
@@ -119,7 +119,7 @@ class LockerApplicationsController < ApplicationController
         format.json { render :show, status: :ok, location: @locker_application }
       else
         @locker_application.user ||= User.new
-        format.html { redirect_to(action: method, id: @locker_application.id) }
+        format.html { render method, status: :unprocessable_entity }
         format.json { render json: @locker_application.errors, status: :unprocessable_entity }
       end
     end

--- a/spec/features/locker_application_new_spec.rb
+++ b/spec/features/locker_application_new_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'Locker Application New', type: :feature, js: true do
         allow(Flipflop).to receive(:lewis_patrons?).and_return(false)
       end
 
-      it 'runs a test' do
+      it 'cannot assign an application to a non-existent user' do
         visit root_path
         expect(page).to have_content('Firestone Locker Application')
         expect(page).to have_field('Applicant Netid',  with: admin.uid)

--- a/spec/features/locker_application_new_spec.rb
+++ b/spec/features/locker_application_new_spec.rb
@@ -82,6 +82,79 @@ RSpec.describe 'Locker Application New', type: :feature, js: true do
     end
   end
 
+  context 'with an administrator' do
+    let(:admin) { FactoryBot.create(:user, admin: true) }
+
+    before do
+      sign_in admin
+    end
+
+    context 'with lewis_patrons on' do
+      before do
+        allow(Flipflop).to receive(:lewis_patrons?).and_return(true)
+      end
+
+      context 'with an existing user' do
+        before do
+          user
+        end
+
+        it 'can assign the application to an existing user' do
+          visit root_path
+          select('Firestone Library', from: :locker_application_building_id)
+          click_button('Next')
+          new_application = LockerApplication.last
+          expect(new_application.user).to eq(admin)
+          expect(page).to have_content('Firestone Locker Application')
+          expect(page).to have_field('Applicant Netid', with: admin.uid)
+          fill_in('Applicant Netid', with: user.uid, fill_options: { clear: :backspace })
+          check('Accessible')
+          expect(page).to have_field('Applicant Netid', with: user.uid)
+          click_button('Submit Locker Application')
+          expect(page).not_to have_content('User must exist')
+          expect(page).to have_current_path(locker_application_path(new_application))
+          expect(new_application.reload.user).to eq(user)
+        end
+      end
+
+      context 'with a user that does not exist yet' do
+        it 'cannot assign an application to a non-existent user' do
+          visit root_path
+          select('Firestone Library', from: :locker_application_building_id)
+          click_button('Next')
+          new_application = LockerApplication.last
+          expect(new_application.user).to eq(admin)
+          expect(page).to have_content('Firestone Locker Application')
+          expect(page).to have_field('Applicant Netid', with: admin.uid)
+          fill_in('Applicant Netid', with: 'arbitrary netid', fill_options: { clear: :backspace })
+          check('Accessible')
+          expect(page).to have_field('Applicant Netid', with: 'arbitrary netid')
+          click_button('Submit Locker Application')
+          expect(page).to have_content('User must exist')
+          expect(page).to have_current_path(locker_application_path(new_application))
+          expect(new_application.reload.user).to eq(admin)
+        end
+      end
+    end
+
+    context 'with lewis_patrons off' do
+      before do
+        allow(Flipflop).to receive(:lewis_patrons?).and_return(false)
+      end
+
+      it 'runs a test' do
+        visit root_path
+        expect(page).to have_content('Firestone Locker Application')
+        expect(page).to have_field('Applicant Netid',  with: admin.uid)
+        fill_in('Applicant Netid', with: 'arbitrary netid', fill_options: { clear: :backspace })
+        check('Accessible')
+        expect(page).to have_field('Applicant Netid', with: 'arbitrary netid')
+        click_button('Submit Locker Application')
+        expect(page).to have_content('User must exist')
+      end
+    end
+  end
+
   context 'with an unauthenticated user' do
     it 'redirects the user to the sign in' do
       visit root_path


### PR DESCRIPTION
Connected to #146 

- This brings us back to parity, where if the user does not exist, the administrator sees the error.
- Future work is creating the user if they don't exist & it's a valid uid against ldap