### PR TITLE
Create user input by Admin if not in system

### DIFF
--- a/app/controllers/locker_applications_controller.rb
+++ b/app/controllers/locker_applications_controller.rb
@@ -79,6 +79,8 @@ class LockerApplicationsController < ApplicationController
   end
 
   def lookup_objects_from_params
+    # If a user_uid is not passed in, something suspicious is going on and should raise an error
+    params.require(:locker_application).require(:user_uid)
     locker_params = params.require(:locker_application).permit(:preferred_size, :preferred_general_area, :accessible, :semester,
                                                                :status_at_application, :department_at_application, :user_uid, :building_id, :complete)
 
@@ -98,8 +100,8 @@ class LockerApplicationsController < ApplicationController
     uid = locker_params.delete(:user_uid)
     user = if current_user.uid == uid
              current_user
-           else
-             User.find_by(uid: uid)
+           elsif current_user.admin?
+             User.from_uid(uid)
            end
     locker_params[:user] = user
     locker_params

--- a/spec/features/locker_application_new_spec.rb
+++ b/spec/features/locker_application_new_spec.rb
@@ -117,8 +117,8 @@ RSpec.describe 'Locker Application New', type: :feature, js: true do
         end
       end
 
-      context 'with a user that does not exist yet' do
-        it 'cannot assign an application to a non-existent user' do
+      context 'with a valid user that does not exist yet' do
+        it 'can create and assign an application to a new user' do
           visit root_path
           select('Firestone Library', from: :locker_application_building_id)
           click_button('Next')
@@ -130,9 +130,8 @@ RSpec.describe 'Locker Application New', type: :feature, js: true do
           check('Accessible')
           expect(page).to have_field('Applicant Netid', with: 'arbitrary netid')
           click_button('Submit Locker Application')
-          expect(page).to have_content('User must exist')
+          expect(page).not_to have_content('User must exist')
           expect(page).to have_current_path(locker_application_path(new_application))
-          expect(new_application.reload.user).to eq(admin)
         end
       end
     end
@@ -142,7 +141,7 @@ RSpec.describe 'Locker Application New', type: :feature, js: true do
         allow(Flipflop).to receive(:lewis_patrons?).and_return(false)
       end
 
-      it 'cannot assign an application to a non-existent user' do
+      it 'can create and assign an application to a new user' do
         visit root_path
         expect(page).to have_content('Firestone Locker Application')
         expect(page).to have_field('Applicant Netid',  with: admin.uid)
@@ -150,7 +149,11 @@ RSpec.describe 'Locker Application New', type: :feature, js: true do
         check('Accessible')
         expect(page).to have_field('Applicant Netid', with: 'arbitrary netid')
         click_button('Submit Locker Application')
-        expect(page).to have_content('User must exist')
+        new_application = LockerApplication.last
+        expect(page).not_to have_content('User must exist')
+        expect(page).to have_current_path(locker_application_path(new_application))
+        new_user = User.last
+        expect(new_application.user).to eq(new_user)
       end
     end
   end

--- a/spec/requests/locker_applications_spec.rb
+++ b/spec/requests/locker_applications_spec.rb
@@ -56,28 +56,6 @@ RSpec.describe '/locker_applications', type: :request do
       user_uid: user.uid
     }
   end
-  # let(:invalid_attributes) do
-  #   {
-  #     preferred_size: 2,
-  #     preferred_general_area: 'Preferred General Area',
-  #     accessible: false,
-  #     semester: 'Semester',
-  #     status_at_application: 'Status At Application',
-  #     department_at_application: 'Department At Application',
-  #     user_id: nil
-  #   }
-  # end
-  # let(:invalid_form_attributes) do
-  #   {
-  #     preferred_size: 2,
-  #     preferred_general_area: 'Preferred General Area',
-  #     accessible: false,
-  #     semester: 'Semester',
-  #     status_at_application: 'Status At Application',
-  #     department_at_application: 'Department At Application',
-  #     user_uid: nil
-  #   }
-  # end
   let(:archived_attributes) do
     {
       building_id: building_one.id,

--- a/spec/requests/locker_applications_spec.rb
+++ b/spec/requests/locker_applications_spec.rb
@@ -32,19 +32,9 @@ RSpec.describe '/locker_applications', type: :request do
       user_uid: user.uid
     }
   end
-  let(:invalid_attributes) do
+  let(:invalid_no_user_attributes) do
     {
-      preferred_size: 2,
-      preferred_general_area: 'Preferred General Area',
-      accessible: false,
-      semester: 'Semester',
-      status_at_application: 'Status At Application',
-      department_at_application: 'Department At Application',
-      user_id: nil
-    }
-  end
-  let(:invalid_form_attributes) do
-    {
+      building_id: building_one.id,
       preferred_size: 2,
       preferred_general_area: 'Preferred General Area',
       accessible: false,
@@ -54,6 +44,40 @@ RSpec.describe '/locker_applications', type: :request do
       user_uid: nil
     }
   end
+  let(:invalid_no_building_attributes) do
+    {
+      building_id: nil,
+      preferred_size: 2,
+      preferred_general_area: 'Preferred General Area',
+      accessible: false,
+      semester: 'Semester',
+      status_at_application: 'Status At Application',
+      department_at_application: 'Department At Application',
+      user_uid: user.uid
+    }
+  end
+  # let(:invalid_attributes) do
+  #   {
+  #     preferred_size: 2,
+  #     preferred_general_area: 'Preferred General Area',
+  #     accessible: false,
+  #     semester: 'Semester',
+  #     status_at_application: 'Status At Application',
+  #     department_at_application: 'Department At Application',
+  #     user_id: nil
+  #   }
+  # end
+  # let(:invalid_form_attributes) do
+  #   {
+  #     preferred_size: 2,
+  #     preferred_general_area: 'Preferred General Area',
+  #     accessible: false,
+  #     semester: 'Semester',
+  #     status_at_application: 'Status At Application',
+  #     department_at_application: 'Department At Application',
+  #     user_uid: nil
+  #   }
+  # end
   let(:archived_attributes) do
     {
       building_id: building_one.id,
@@ -249,17 +273,25 @@ RSpec.describe '/locker_applications', type: :request do
         end
       end
 
-      context 'with invalid parameters' do
-        it 'redirects to root' do
+      context 'with invalid building attributes' do
+        it 'does not create a new application' do
           expect do
-            post locker_applications_url, params: { locker_application: invalid_form_attributes }
+            post locker_applications_url, params: { locker_application: invalid_no_building_attributes }
           end.not_to change(LockerApplication, :count)
-          expect(response).to redirect_to(root_path)
         end
 
-        it 'redirects to root' do
-          post locker_applications_url, params: { locker_application: invalid_form_attributes }
-          expect(response).to redirect_to(root_path)
+        it 'is unprocessable' do
+          post locker_applications_url, params: { locker_application: invalid_no_building_attributes }
+          expect(response).to be_unprocessable
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context 'with no user passed in' do
+        it 'raises an error do' do
+          expect do
+            post locker_applications_url, params: { locker_application: invalid_no_user_attributes }
+          end.to raise_error(ActionController::ParameterMissing)
         end
       end
     end
@@ -298,7 +330,7 @@ RSpec.describe '/locker_applications', type: :request do
     context 'with invalid parameters' do
       it 'redirects to root' do
         locker_application = LockerApplication.create! valid_attributes
-        patch locker_application_url(locker_application), params: { locker_application: invalid_form_attributes }
+        patch locker_application_url(locker_application), params: { locker_application: invalid_no_user_attributes }
         expect(response).to redirect_to(root_path)
       end
     end
@@ -399,17 +431,25 @@ RSpec.describe '/locker_applications', type: :request do
         end
       end
 
-      context 'with invalid parameters' do
+      context 'with no building passed in' do
         it 'does not create a new LockerApplication' do
           expect do
-            post locker_applications_url, params: { locker_application: invalid_form_attributes }
+            post locker_applications_url, params: { locker_application: invalid_no_building_attributes }
           end.not_to change(LockerApplication, :count)
         end
 
         it "renders a successful response (i.e. to display the 'new' template)" do
-          post locker_applications_url, params: { locker_application: invalid_form_attributes }
+          post locker_applications_url, params: { locker_application: invalid_no_building_attributes }
           expect(response).to be_unprocessable
           expect(response).to render_template(:new)
+        end
+      end
+
+      context 'with no user passed in' do
+        it 'raises an error' do
+          expect do
+            post locker_applications_url, params: { locker_application: invalid_no_user_attributes }
+          end.to raise_error(ActionController::ParameterMissing)
         end
       end
     end
@@ -445,11 +485,22 @@ RSpec.describe '/locker_applications', type: :request do
       end
 
       context 'with invalid parameters' do
-        it "renders a successful response (i.e. to display the 'edit' template)" do
-          locker_application = LockerApplication.create! valid_attributes
-          patch locker_application_url(locker_application), params: { locker_application: invalid_form_attributes }
-          expect(response).to be_unprocessable
-          expect(response).to render_template(:edit)
+        context 'with no user_uid' do
+          it 'raises an error' do
+            locker_application = LockerApplication.create! valid_attributes
+            expect do
+              patch locker_application_url(locker_application), params: { locker_application: invalid_no_user_attributes }
+            end.to raise_error(ActionController::ParameterMissing)
+          end
+        end
+
+        context 'with no building id' do
+          it "renders a successful response (i.e. to display the 'edit' template)" do
+            locker_application = LockerApplication.create! valid_attributes
+            patch locker_application_url(locker_application), params: { locker_application: invalid_no_building_attributes }
+            expect(response).to be_unprocessable
+            expect(response).to render_template(:edit)
+          end
         end
       end
     end


### PR DESCRIPTION
Closes #146 

- user_uid is required
- tests - behavior of form is different with missing user_uid vs. missing building or other param (user_uid raises error, missing building gives message)
- Split out CAS verification into #161