### PR TITLE
Handle flash of unstyled content

### DIFF
--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -7,6 +7,7 @@ Vue.use(system)
 
 // create the LUX app and mount it to wrappers with class="lux"
 document.addEventListener("DOMContentLoaded", () => {
+  document.getElementsByTagName('html')[0].classList.remove("loading");
   var elements = document.getElementsByClassName("lux")
   for (var i = 0; i < elements.length; i++) {
     new Vue({

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" class="loading">
   <head>
+    <style>.loading { display: none }</style>
     <title>LockerAndStudySpaces</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
Since vite creates es modules, which are deferred, there can be quite some time before the DOM is parsed (and displayed to the user) and the lux app is actually mounted.

Let's use a big hammer: display:none until it's time for the lux app to be mounted.

Closes #155 