### PR TITLE
Address a few local test failures

### DIFF
--- a/spec/features/locker_application_assign_spec.rb
+++ b/spec/features/locker_application_assign_spec.rb
@@ -38,7 +38,10 @@ RSpec.describe 'Locker Application Assign', :js do
     expect(page).to have_text('Preferred general area: A floor')
     select locker.location, from: 'locker_assignment_locker_id'
 
-    expect { click_button 'Submit Locker Assignment' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect do
+      click_button 'Submit Locker Assignment'
+      expect(page).to have_current_path %r{/locker_assignments/\d+}
+    end.to change { ActionMailer::Base.deliveries.count }.by(1)
     click_link 'Card for printing'
   end
 

--- a/spec/features/locker_application_new_spec.rb
+++ b/spec/features/locker_application_new_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'Locker Application New', :js do
         # Submit library as first step
         expect do
           click_button('Next')
+          expect(page).to have_current_path %r{/locker_applications/\d+/edit}
         end.to change(LockerApplication, :count)
         expect(page).to have_current_path(edit_locker_application_path(id: LockerApplication.last.id), ignore_query: true)
         # Since the application is still incomplete, we don't show the "successfully created" message yet
@@ -47,6 +48,7 @@ RSpec.describe 'Locker Application New', :js do
         visit root_path
         select('Firestone Library', from: :locker_application_building_id)
         click_button('Next')
+        expect(page).to have_current_path %r{/locker_applications/\d+/edit}
         new_application = LockerApplication.last
         expect(page).to have_content('Firestone Library Locker Application')
         expect(page).to have_select('Preferred Size', options: %w[4-foot 6-foot])
@@ -241,6 +243,7 @@ RSpec.describe 'Locker Application New', :js do
         fill_in('Applicant Netid', with: 'arbitrary netid', fill_options: { clear: :backspace })
         expect(page).to have_field('Applicant Netid', with: 'arbitrary netid')
         click_button('Submit Locker Application')
+        expect(page).to have_current_path %r{/locker_applications/\d+$}
         new_application = LockerApplication.last
         expect(page).not_to have_content('User must exist')
         expect(page).to have_current_path(locker_application_path(new_application))
@@ -261,6 +264,7 @@ RSpec.describe 'Locker Application New', :js do
         expect(page).to have_field('Additional accessibility needs', with: 'Another need')
         uncheck('Keyed entry (rather than combination)')
         click_button('Submit Locker Application')
+        expect(page).to have_current_path %r{/locker_applications/\d+$}
         expect(locker_application.reload.accessibility_needs).to contain_exactly('Another need')
       end
     end

--- a/spec/features/locker_create_spec.rb
+++ b/spec/features/locker_create_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Locker Create', :js do
 
     expect do
       click_button 'Submit Locker'
+      expect(page).to have_current_path %r{/lockers/\d+}
     end.to change(Locker, :count).by(1)
 
     expect(Locker.order('created_at').last.building).to eq(building)

--- a/spec/features/locker_violation_spec.rb
+++ b/spec/features/locker_violation_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe 'Locker Violation', :js do
     expect(page).to have_text(locker_assignment.locker.location)
     click_link 'Record Violation'
     fill_in :locker_violation_number_of_books, with: 2
-    expect { click_button 'Record Locker Violation' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect do
+      click_button 'Record Locker Violation'
+      expect(page).to have_current_path %r{/locker_violations/\d+}
+    end.to change { ActionMailer::Base.deliveries.count }.by(1)
   end
 end

--- a/spec/features/scheduled_message_spec.rb
+++ b/spec/features/scheduled_message_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe ScheduledMessage, :js do
 
       expect do
         click_button 'Submit'
+        expect(page).to have_current_path %r{/locker_renewal_messages/\d+}
       end.to change(described_class, :count).by(1)
     end
 
@@ -75,6 +76,7 @@ RSpec.describe ScheduledMessage, :js do
 
       expect do
         click_button 'Submit'
+        expect(page).to have_current_path %r{/locker_renewal_messages/\d+}
       end.to change(described_class, :count).by(1)
     end
 

--- a/spec/features/study_room_violation_spec.rb
+++ b/spec/features/study_room_violation_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe 'Study Room Violation', :js do
     expect(page).to have_text(study_room_assignment.study_room.location)
     click_link 'Record Violation'
     fill_in :study_room_violation_number_of_books, with: 2
-    expect { click_button 'Record Violation' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect do
+      click_button 'Record Violation'
+      expect(page).to have_current_path %r{/study_room_violations/\d+}
+    end.to change { ActionMailer::Base.deliveries.count }.by(1)
   end
 end


### PR DESCRIPTION
These are cases in which we attempted to check or assign a value immediately after clicking a button or similar.  This PR adds additional assertions before using the needed value, so that Capybara can make sure that we have reached the subsequent page and the value is ready.