### PR TITLE
Fix a few more local test failures

### DIFF
--- a/spec/features/locker_application_new_spec.rb
+++ b/spec/features/locker_application_new_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'Locker Application New', :js do
         expect(page).not_to have_content('Application successfully created')
       end
 
+      # rubocop:disable RSpec/MultipleExpectations
       it 'can apply for a new locker' do
         visit root_path
         select('Firestone Library', from: :locker_application_building_id)
@@ -63,16 +64,19 @@ RSpec.describe 'Locker Application New', :js do
         select('4-foot', from: :locker_application_preferred_size)
         expect(new_application.reload.complete).to be false
         click_button('Submit Locker Application')
+        expect(page).to have_current_path %r{/locker_applications/\d+$}
         new_application.reload
         expect(new_application.preferred_size).to eq(4)
         expect(new_application.complete).to be true
         expect(page).to have_current_path(locker_application_path(new_application))
       end
+      # rubocop:enable RSpec/MultipleExpectations
 
       it 'can apply for a new Lewis locker' do
         visit root_path
         select('Lewis Library', from: :locker_application_building_id)
         click_button('Next')
+        expect(page).to have_current_path %r{/locker_applications/\d+/edit$}
         new_application = LockerApplication.last
         expect(page).to have_content('Lewis Library Locker Application')
         expect(page).to have_select('Preferred Size', options: ['25" x 12"'], disabled: true)
@@ -96,6 +100,7 @@ RSpec.describe 'Locker Application New', :js do
         visit root_path
         select('Firestone Library', from: :locker_application_building_id)
         click_button('Next')
+        expect(page).to have_current_path %r{/locker_applications/\d+/edit$}
         new_application = LockerApplication.last
         expect(page).to have_unchecked_field('Keyed entry (rather than combination)')
         check('Keyed entry (rather than combination)')
@@ -104,6 +109,7 @@ RSpec.describe 'Locker Application New', :js do
         expect(page).to have_field('Additional accessibility needs')
         fill_in('Additional accessibility needs', with: 'Not low to the ground')
         click_button('Submit Locker Application')
+        expect(page).to have_current_path %r{/locker_applications/\d+$}
         new_application.reload
         expect(new_application.accessibility_needs).to contain_exactly('Keyed entry (rather than combination)', 'Near an elevator',
                                                                        'Not low to the ground')
@@ -113,10 +119,12 @@ RSpec.describe 'Locker Application New', :js do
         visit root_path
         select('Firestone Library', from: :locker_application_building_id)
         click_button('Next')
+        expect(page).to have_current_path %r{/locker_applications/\d+/edit$}
         new_application = LockerApplication.last
         expect(page).to have_field('Additional accessibility needs')
         check('Keyed entry (rather than combination)')
         click_button('Submit Locker Application')
+        expect(page).to have_current_path %r{/locker_applications/\d+$}
         new_application.reload
         expect(new_application.accessibility_needs).to contain_exactly('Keyed entry (rather than combination)')
       end
@@ -181,6 +189,7 @@ RSpec.describe 'Locker Application New', :js do
           fill_in('Applicant Netid', with: user.uid, fill_options: { clear: :backspace })
           expect(page).to have_field('Applicant Netid', with: user.uid)
           click_button('Submit Locker Application')
+          expect(page).to have_current_path %r{/locker_applications/\d+/edit$}
           new_application = LockerApplication.last
           expect(page).not_to have_content('User must exist')
           expect(page).to have_current_path(edit_locker_application_path(new_application))
@@ -198,6 +207,7 @@ RSpec.describe 'Locker Application New', :js do
           fill_in('Additional accessibility needs', with: 'Lower row')
           expect(page).to have_field('Applicant Netid', with: 'arbitrary netid')
           click_button('Submit Locker Application')
+          expect(page).to have_current_path %r{/locker_applications/\d+/edit$}
           new_application = LockerApplication.last
           expect(page).not_to have_content('User must exist')
           expect(page).to have_current_path(edit_locker_application_path(new_application))

--- a/spec/features/scheduled_message_spec.rb
+++ b/spec/features/scheduled_message_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ScheduledMessage, :js do
 
       expect do
         click_button 'Submit'
-        expect(page).to have_current_path %r{/locker_renewal_messages/\d+}
+        expect(page).to have_current_path %r{/locker_renewal_messages/\d+$}
       end.to change(described_class, :count).by(1)
     end
 
@@ -53,6 +53,7 @@ RSpec.describe ScheduledMessage, :js do
 
       expect do
         click_link 'Remove from schedule'
+        expect(page).to have_current_path '/locker_renewal_messages'
       end.to change(described_class, :count).by(-1)
     end
   end
@@ -76,7 +77,7 @@ RSpec.describe ScheduledMessage, :js do
 
       expect do
         click_button 'Submit'
-        expect(page).to have_current_path %r{/locker_renewal_messages/\d+}
+        expect(page).to have_current_path %r{/locker_renewal_messages/\d+$}
       end.to change(described_class, :count).by(1)
     end
 
@@ -85,6 +86,7 @@ RSpec.describe ScheduledMessage, :js do
 
       expect do
         click_link 'Remove from schedule'
+        expect(page).to have_current_path '/locker_renewal_messages'
       end.to change(described_class, :count).by(-1)
     end
   end

--- a/spec/features/study_room_assign_spec.rb
+++ b/spec/features/study_room_assign_spec.rb
@@ -47,9 +47,11 @@ RSpec.describe 'Study Room Assign', :js do
     # fill in users
     fill_in "study_room_assignment_#{study_room2.id}_user_netid", with: user2.uid
 
-    expect { click_button 'Update Assignments' }
-      .to change { StudyRoomAssignment.count }.by(1)
-                                              .and not_change { User.count }
+    expect do
+      click_button 'Update Assignments'
+      sleep 1 # We can't use Capybara's typical waiting capabilities, since the page does not change
+    end.to change { StudyRoomAssignment.count }.by(1)
+                                               .and not_change { User.count }
       .and change {
              ActionMailer::Base.deliveries.count
            }.by(1)
@@ -67,11 +69,13 @@ RSpec.describe 'Study Room Assign', :js do
     # fill in users
     fill_in "study_room_assignment_#{study_room2.id}_user_netid", with: 'abc123'
 
-    expect { click_button 'Update Assignments' }
-      .to change { StudyRoomAssignment.count }.by(1).and change { User.count }.by(1)
-                                                                              .and change {
-                                                                                     ActionMailer::Base.deliveries.count
-                                                                                   }.by(1)
+    expect do
+      click_button 'Update Assignments'
+      sleep 1 # We can't use Capybara's typical waiting capabilities, since the page does not change
+    end.to change { StudyRoomAssignment.count }.by(1).and change { User.count }.by(1)
+                                                                               .and change {
+                                                                                      ActionMailer::Base.deliveries.count
+                                                                                    }.by(1)
   end
 
   it 'unasigns a user if the uid is blank' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -90,6 +90,7 @@ RSpec.configure do |config|
                                else
                                  :chrome_headless
                                end
+  Capybara.default_max_wait_time = 4
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view


### PR DESCRIPTION
* Add some assertions that cause Capybara to wait before certain checks and variable assignments.
* Increase the capybara default wait time
* Add some `sleep`s where it was unavoidable (the interface in question does not change or reload at all, it sends a javascript request behind the scenes, with no indication to the user that anything has happened, so I couldn't find a Capybara tool that would wait the appropriate amount of time).