### PR TITLE
Don't install firefox in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,8 @@ jobs:
       - setup-bundler
 
 
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run:
           command: |
             google-chrome --version


### PR DESCRIPTION
We run the tests in chrome only, so there is no need to install firefox.