### PR TITLE
Remove rails gems we don't use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,13 @@
 source 'https://gem.coop'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 8.1'
+gem 'actionmailer'
+gem 'actionpack'
+gem 'actionview'
+gem 'activemodel'
+gem 'activerecord'
+gem 'activesupport'
+
 # Use postgresql as the database for Active Record
 gem 'pg'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,6 @@
 GEM
   remote: https://gem.coop/
   specs:
-    action_text-trix (2.1.18)
-      railties
-    actioncable (8.1.3)
-      actionpack (= 8.1.3)
-      activesupport (= 8.1.3)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-      zeitwerk (~> 2.6)
-    actionmailbox (8.1.3)
-      actionpack (= 8.1.3)
-      activejob (= 8.1.3)
-      activerecord (= 8.1.3)
-      activestorage (= 8.1.3)
-      activesupport (= 8.1.3)
-      mail (>= 2.8.0)
     actionmailer (8.1.3)
       actionpack (= 8.1.3)
       actionview (= 8.1.3)
@@ -33,14 +18,6 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actiontext (8.1.3)
-      action_text-trix (~> 2.1.15)
-      actionpack (= 8.1.3)
-      activerecord (= 8.1.3)
-      activestorage (= 8.1.3)
-      activesupport (= 8.1.3)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
     actionview (8.1.3)
       activesupport (= 8.1.3)
       builder (~> 3.1)
@@ -56,12 +33,6 @@ GEM
       activemodel (= 8.1.3)
       activesupport (= 8.1.3)
       timeout (>= 0.4.0)
-    activestorage (8.1.3)
-      actionpack (= 8.1.3)
-      activejob (= 8.1.3)
-      activerecord (= 8.1.3)
-      activesupport (= 8.1.3)
-      marcel (~> 1.0)
     activesupport (8.1.3)
       base64
       bigdecimal
@@ -184,7 +155,6 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.4)
     matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (6.0.6)
@@ -269,20 +239,6 @@ GEM
       rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
-    rails (8.1.3)
-      actioncable (= 8.1.3)
-      actionmailbox (= 8.1.3)
-      actionmailer (= 8.1.3)
-      actionpack (= 8.1.3)
-      actiontext (= 8.1.3)
-      actionview (= 8.1.3)
-      activejob (= 8.1.3)
-      activemodel (= 8.1.3)
-      activerecord (= 8.1.3)
-      activestorage (= 8.1.3)
-      activesupport (= 8.1.3)
-      bundler (>= 1.15.0)
-      railties (= 8.1.3)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
@@ -425,10 +381,6 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
     websocket (1.2.11)
-    websocket-driver (0.7.7)
-      base64
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     whenever (1.0.0)
       chronic (>= 0.6.3)
     xpath (3.2.0)
@@ -446,6 +398,12 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  actionmailer
+  actionpack
+  actionview
+  activemodel
+  activerecord
+  activesupport
   axe-core-rspec
   bcrypt_pbkdf
   bootsnap (>= 1.1.0)
@@ -470,7 +428,6 @@ DEPENDENCIES
   pagy (< 5.0.0)
   pg
   puma
-  rails (~> 8.1)
   rails-controller-testing
   rspec-rails
   rspec_junit_formatter

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,9 +33,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
-
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,14 +31,6 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
-
-  # Mount Action Cable outside main process or domain
-  # config.action_cable.mount_path = nil
-  # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
-
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -31,14 +31,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
-
-  # Mount Action Cable outside main process or domain
-  # config.action_cable.mount_path = nil
-  # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
-
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,9 +34,6 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
-
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.


### PR DESCRIPTION
Addresses CVE-2026-66066 (which we were not vulnerable to, since we don't accept image uploads then display them) and CVE-2026-61666